### PR TITLE
add note that DB upgrade must not be combined with stemcell upgrade

### DIFF
--- a/lit/release-notes/v3.5.0.lit
+++ b/lit/release-notes/v3.5.0.lit
@@ -38,6 +38,8 @@
       single-vm
       manifest}{https://github.com/concourse/concourse/commit/17be5f144a799e344c9d1bb56d9595ff164c96ef}
       as a reference.)
+    }{
+      Note that the Postgres DB upgrade must not be combined in the same deployment operation with a stemcell update.
     }
   }
 


### PR DESCRIPTION
otherwise DB upgrade will fail because both old and new postgres packages must be available in order to do a major version upgrade.